### PR TITLE
Mc fixes

### DIFF
--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1171,7 +1171,7 @@ class Gradebook(object):
                     group_name=group_name
                 ))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                self.log.error("Error caught: " + e)
+                #self.log.error("Error caught: " + e) # self.log not working. Gradebook has no attribute log
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error 
                     # Note: check if log ever appears.
@@ -1179,10 +1179,10 @@ class Gradebook(object):
                         student=student_id,
                         group_name=group_name
                     )
-                    print(err_msg + e)
-                    self.log.error(err_msg)
+                    print(err_msg + str(e))
+                    #self.log.error(err_msg)
                 print("Make sure you set a valid api_token in your config file before starting the service")
-                self.log.error("Make sure you set a valid api_token in your config file before starting the service")
+                #self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)
@@ -1264,17 +1264,17 @@ class Gradebook(object):
 
             try:
                 group_name = "nbgrader-{}".format(self.course_id)
-                utils.query_jupyterhub_api(method="DELETE",
+                res = utils.query_jupyterhub_api(method="DELETE",
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student.id]}
                 )
                 # log.info
-                print("Student {student} removed from the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
+                print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
                     print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
-                self.log.error("Error caught in remove_student(): " + e)
+                #self.log.error("Error caught in remove_student(): " + e)
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1271,7 +1271,7 @@ class Gradebook(object):
                 # log.info
                 print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                if self.course_id: # we assume user might be using Jupyterhub but something is not working
+                if self.course_id: # We assume user might be using Jupyterhub but something is not working
                     # log.error
                     print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
                 #self.log.error("Error caught in remove_student(): " + e)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1170,14 +1170,15 @@ class Gradebook(object):
                     student=student_id,
                     group_name=group_name
                 ))
-            except utils.JupyterhubEnvironmentError as e:
+            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
+
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
-                    print("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                    self.log.error("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
                     ) + str(e))
-
+                self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1173,11 +1173,15 @@ class Gradebook(object):
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
                 self.log.error("Error caught: " + e)
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
-                    # log.error
-                    self.log.error("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                    # log.error 
+                    # Note: check if log ever appears.
+                    err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
-                    ))
+                    )
+                    print(err_msg + e)
+                    self.log.error(err_msg)
+                print("Make sure you set a valid api_token in your config file before starting the service")
                 self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1171,13 +1171,13 @@ class Gradebook(object):
                     group_name=group_name
                 ))
             except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-
+                self.log.error("Error caught: " + e)
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
                     self.log.error("Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
-                    ) + str(e))
+                    ))
                 self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1270,11 +1270,11 @@ class Gradebook(object):
                 )
                 # log.info
                 print("Student {student} removed from the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
-            except utils.JupyterhubEnvironmentError as e:
+            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
                 if self.course_id: # we assume user might be using Jupyterhub but something is not working
                     # log.error
                     print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
-
+                self.log.error("Error caught in remove_student(): " + e)
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1272,11 +1272,11 @@ class Gradebook(object):
                 )
                 print("Student {student} was removed or was already not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except utils.JupyterhubEnvironmentError as e:
-                print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
+                print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
                 #self.log.error("Error caught in remove_student(): " + e)
             except utils.JupyterhubApiError as e:
                 if self.course_id:
-                    print("Student {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
+                    print("Student {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
                     print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1158,14 +1158,18 @@ class Gradebook(object):
             self.db.commit()
             try:
                 group_name = "nbgrader-{}".format(self.course_id)
-                utils.query_jupyterhub_api(method="POST",
-                                     api_path="/groups/{name}".format(name=group_name),
+                jup_groups = utils.query_jupyterhub_api(method="GET",
+                                     api_path="/groups",
                 )
+                if group_name not in [x['name'] for x in jup_groups]
+                    # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
+                    utils.query_jupyterhub_api(method="POST",
+                                         api_path="/groups/{name}".format(name=group_name),
+                    )
                 utils.query_jupyterhub_api(method="POST",
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}
                 )
-                # log.info
                 print("Student {student} added to Jupyterhub group {group_name}".format(
                     student=student_id,
                     group_name=group_name

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1170,19 +1170,16 @@ class Gradebook(object):
                     student=student_id,
                     group_name=group_name
                 ))
-            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                #self.log.error("Error caught: " + e) # self.log not working. Gradebook has no attribute log
-                if self.course_id: # we assume user might be using Jupyterhub but something is not working
-                    # log.error 
-                    # Note: check if log ever appears.
+            except utils.JupyterhubEnvironmentError as e:
+                print("Not running on Jupyterhub, not adding {student} user to Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
+            except utils.JupyterhubApiError as e:
+                if self.course_id: # We assume user might be using Jupyterhub but something is not working
                     err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
                     )
-                    print(err_msg + str(e))
-                    #self.log.error(err_msg)
+                print(err_msg + str(e))
                 print("Make sure you set a valid api_token in your config file before starting the service")
-                #self.log.error("Make sure you set a valid api_token in your config file before starting the service")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1161,7 +1161,6 @@ class Gradebook(object):
                 jup_groups = utils.query_jupyterhub_api(method="GET",
                                      api_path="/groups",
                 )
-                self.log.info([x['name'] for x in jup_groups])
                 if group_name not in [x['name'] for x in jup_groups]:
                     # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
                     utils.query_jupyterhub_api(method="POST",

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1276,7 +1276,7 @@ class Gradebook(object):
             except utils.JupyterhubApiError as e:
                 if self.course_id:
                     print("Student {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
-                    print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
+                    print("Make sure you start your service with a valid admin_user 'api_token' in your Jupyterhub config")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1161,11 +1161,12 @@ class Gradebook(object):
                 jup_groups = utils.query_jupyterhub_api(method="GET",
                                      api_path="/groups",
                 )
-                if group_name not in [x['name'] for x in jup_groups]
+                if group_name not in [x['name'] for x in jup_groups]:
                     # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
                     utils.query_jupyterhub_api(method="POST",
                                          api_path="/groups/{name}".format(name=group_name),
                     )
+                    print("Jupyterhub group: {group_name} created.".format(group_name=group_name) )
                 utils.query_jupyterhub_api(method="POST",
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1161,6 +1161,7 @@ class Gradebook(object):
                 jup_groups = utils.query_jupyterhub_api(method="GET",
                                      api_path="/groups",
                 )
+                self.log.info([x['name'] for x in jup_groups])
                 if group_name not in [x['name'] for x in jup_groups]:
                     # This could result in a bad request(JupyterhubApiError) if there is already a group so first we check above if there is a group
                     utils.query_jupyterhub_api(method="POST",
@@ -1171,15 +1172,15 @@ class Gradebook(object):
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student_id]}
                 )
-                print("Student {student} added to Jupyterhub group {group_name}".format(
+                print("Student {student} added to the Jupyterhub group {group_name}".format(
                     student=student_id,
                     group_name=group_name
                 ))
             except utils.JupyterhubEnvironmentError as e:
-                print("Not running on Jupyterhub, not adding {student} user to Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
+                print("Not running on Jupyterhub, not adding {student} user to the Jupyterhub group {group_name}".format(student=student_id, group_name=group_name))
             except utils.JupyterhubApiError as e:
                 if self.course_id: # We assume user might be using Jupyterhub but something is not working
-                    err_msg = "Student {student} NOT added to Jupyterhub group {group_name}: ".format(
+                    err_msg = "Student {student} NOT added to the Jupyterhub group {group_name}: ".format(
                         student=student_id,
                         group_name=group_name
                     )

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1273,7 +1273,6 @@ class Gradebook(object):
                 print("Student {student} was removed or was already not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
             except utils.JupyterhubEnvironmentError as e:
                 print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))
-                #self.log.error("Error caught in remove_student(): " + e)
             except utils.JupyterhubApiError as e:
                 if self.course_id:
                     print("Student {student} was NOT removed from the Jupyterhub group {group_name}:".format(student=name, group_name=group_name), str(e))

--- a/nbgrader/api.py
+++ b/nbgrader/api.py
@@ -1265,13 +1265,14 @@ class Gradebook(object):
                                      api_path="/groups/{name}/users".format(name=group_name),
                                      post_data = {"users":[student.id]}
                 )
-                # log.info
-                print("Student {student} removed or was not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
-            except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
-                if self.course_id: # We assume user might be using Jupyterhub but something is not working
-                    # log.error
-                    print("Student {student} NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name) + str(e))
+                print("Student {student} was removed or was already not in the Jupyterhub group {group_name}".format(student=name, group_name=group_name))
+            except utils.JupyterhubEnvironmentError as e:
+                print("Not running on Jupyterhub so {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
                 #self.log.error("Error caught in remove_student(): " + e)
+            except utils.JupyterhubApiError as e:
+                if self.course_id:
+                    print("Student {student} was NOT removed from the Jupyterhub group {group_name}: ".format(student=name, group_name=group_name), str(e))
+                    print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
         except (IntegrityError, FlushError) as e:
             self.db.rollback()
             raise InvalidEntry(*e.args)

--- a/nbgrader/docs/source/user_guide/installation.rst
+++ b/nbgrader/docs/source/user_guide/installation.rst
@@ -55,12 +55,18 @@ able to use the nbgrader extensions.
 There are a number of ways you may need to customize the installation:
 
 -  To install or enable the nbextensions/serverextension for just the
-   current user, replace ``--sys-prefix`` by ``--user`` in any of the above
-   commands.
+   current user, run the above commands with ``--user`` instead of ``--sys-prefix``::
+    
+    jupyter nbextension install --user --py nbgrader --overwrite
+    jupyter nbextension enable --user --py nbgrader
+    jupyter serverextension enable --user --py nbgrader
 
 -  To install or enable the nbextensions/serverextension for all
-   Python installations on the system, replace ``--sys-prefix`` by ``--system``
-   in any of the above commands.
+   Python installations on the system, run the above commands with ``--system`` instead of ``--sys-prefix``::
+
+    jupyter nbextension install --system --py nbgrader --overwrite
+    jupyter nbextension enable --system --py nbgrader
+    jupyter serverextension enable --system --py nbgrader
 
 -  You can also use the ``--overwrite`` option along with the ``jupyter
    nbextension install`` command to overwrite existing nbgrader extension

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -129,13 +129,17 @@ class Exchange(LoggingConfigurable):
         """Check if student is enrolled in course"""
         if student_id == "*":
             student_id = "{authenticated_user}"
-        response = query_jupyterhub_api('GET', '/users/%s' % student_id)
+        try:
+            response = query_jupyterhub_api('GET', '/users/%s' % student_id)
+        except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
+            self.log.error("Error caught: " + e)
+            self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
         courses = set()
         try:
             for group in response['groups']:
                 if group.startswith('nbgrader-') or group.startswith('formgrade-'):
                     courses.add(group.split('-', 1)[1])
         except KeyError:
-            self.log.error("Error in calling Jupyterhub API: " + str(response)) 
+            self.log.error("KeyError: See Jupyterhub API: " + str(response)) 
             self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
         return list(courses)

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -129,6 +129,7 @@ class Exchange(LoggingConfigurable):
         """Check if student is enrolled in course"""
         if student_id == "*":
             student_id = "{authenticated_user}"
+        response = None
         try:
             response = query_jupyterhub_api('GET', '/users/%s' % student_id)
         except (JupyterhubEnvironmentError, JupyterhubApiError) as e:

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -136,5 +136,6 @@ class Exchange(LoggingConfigurable):
                 if group.startswith('nbgrader-') or group.startswith('formgrade-'):
                     courses.add(group.split('-', 1)[1])
         except KeyError:
-            self.log.error("Error in calling Jupyterhub API: " + str(response) + "Make sure you start your service with a valid 'api_token' in your config file")
+            self.log.error("Error in calling Jupyterhub API: " + str(response)) 
+            self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
         return list(courses)

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -136,5 +136,5 @@ class Exchange(LoggingConfigurable):
                 if group.startswith('nbgrader-') or group.startswith('formgrade-'):
                     courses.add(group.split('-', 1)[1])
         except KeyError:
-            print("Error in calling Jupyterhub API: " + str(response))
+            self.log.error("Error in calling Jupyterhub API: " + str(response) + "Make sure you start your service with a valid 'api_token' in your config file")
         return list(courses)

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -11,7 +11,7 @@ from traitlets.config import LoggingConfigurable
 from traitlets import Unicode, Bool, Instance, default
 from jupyter_core.paths import jupyter_data_dir
 
-from ..utils import check_directory, query_jupyterhub_api
+from ..utils import check_directory, query_jupyterhub_api, JupyterhubEnvironmentError, JupyterhubApiError 
 from ..coursedir import CourseDirectory
 
 class ExchangeError(Exception):
@@ -131,7 +131,7 @@ class Exchange(LoggingConfigurable):
             student_id = "{authenticated_user}"
         try:
             response = query_jupyterhub_api('GET', '/users/%s' % student_id)
-        except (utils.JupyterhubEnvironmentError, utils.JupyterhubApiError) as e:
+        except (JupyterhubEnvironmentError, JupyterhubApiError) as e:
             self.log.error("Error caught: " + e)
             self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
         courses = set()

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -132,7 +132,7 @@ class Exchange(LoggingConfigurable):
         try:
             response = query_jupyterhub_api('GET', '/users/%s' % student_id)
         except (JupyterhubEnvironmentError, JupyterhubApiError) as e:
-            self.log.error("Error caught: " + e)
+            self.log.error("Error caught: " + str(e))
             self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
         courses = set()
         try:

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -140,9 +140,9 @@ class Exchange(LoggingConfigurable):
             return []
         except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
             print(str(e))
-            print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
-            self.log.error("Error: not able to get Jupyterhub user" + student_id + ":" + str(e))
-            self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
+            print("Make sure you start your service with a valid admin_user 'api_token' in your Jupyterhub config")
+            self.log.error("Error: Not able to get Jupyterhub user: " + student_id + ": " + str(e))
+            self.log.error("Make sure you start your service with a valid admin_user 'api_token' in your Jupyterhub config")
             return []
         courses = set()
         try:

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -141,7 +141,7 @@ class Exchange(LoggingConfigurable):
         except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
             print(str(e))
             print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
-            self.log.error("Error: not able to get Jupyterhub user" + student_id, ":", str(e))
+            self.log.error("Error: not able to get Jupyterhub user" + student_id + ":" + str(e))
             self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
             return []
         courses = set()

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -141,7 +141,7 @@ class Exchange(LoggingConfigurable):
         except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
             print(str(e))
             print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
-            self.log.error("Error: not able to get Jupytehub user: {student}".format(student=student),str(e))
+            self.log.error("Error: not able to get Jupytehub user: {student}".format(student=student_id),str(e))
             self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
             return []
         courses = set()

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -141,6 +141,7 @@ class Exchange(LoggingConfigurable):
         except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
             print(str(e))
             print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
+            self.log.error(str(e))
             self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
             return []
         courses = set()

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -141,7 +141,7 @@ class Exchange(LoggingConfigurable):
         except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
             print(str(e))
             print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
-            self.log.error("Error: not able to get Jupytehub user: {student}".format(student=student_id),str(e))
+            self.log.error("Error: not able to get Jupyterhub user" + student_id, ":", str(e))
             self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
             return []
         courses = set()

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -132,15 +132,23 @@ class Exchange(LoggingConfigurable):
         response = None
         try:
             response = query_jupyterhub_api('GET', '/users/%s' % student_id)
-        except (JupyterhubEnvironmentError, JupyterhubApiError) as e:
-            self.log.error("Error caught: " + str(e))
-            self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
+        except JupyterhubEnvironmentError as e: # Should only go here if we are not running on Jupyterhub.
+            print("Not running on Jupyterhub, not able to GET Jupyterhub user")
+            print("Warning: " + str(e)) # ERASE THIS LATER
+            self.log.info('Not running on Jupyterhub, not able to GET Jupyterhub user')
+            self.log.info("Error caught: " + str(e))
+            return []
+        except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
+            print(str(e))
+            print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
+            self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
+            return []
         courses = set()
         try:
             for group in response['groups']:
                 if group.startswith('nbgrader-') or group.startswith('formgrade-'):
                     courses.add(group.split('-', 1)[1])
         except KeyError:
-            self.log.error("KeyError: See Jupyterhub API: " + str(response)) 
-            self.log.error("Make sure you start your service with a valid 'api_token' in your config file")
+            print("KeyError: See Jupyterhub API: " + str(response))
+            self.log.error("KeyError: See Jupyterhub API: " + str(response))
         return list(courses)

--- a/nbgrader/exchange/exchange.py
+++ b/nbgrader/exchange/exchange.py
@@ -134,14 +134,14 @@ class Exchange(LoggingConfigurable):
             response = query_jupyterhub_api('GET', '/users/%s' % student_id)
         except JupyterhubEnvironmentError as e: # Should only go here if we are not running on Jupyterhub.
             print("Not running on Jupyterhub, not able to GET Jupyterhub user")
-            print("Warning: " + str(e)) # ERASE THIS LATER
+            print("Warning: " + str(e))
             self.log.info('Not running on Jupyterhub, not able to GET Jupyterhub user')
             self.log.info("Error caught: " + str(e))
             return []
         except JupyterhubApiError as e: # Should only go here if the api_token is invalid.
             print(str(e))
             print("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
-            self.log.error(str(e))
+            self.log.error("Error: not able to get Jupytehub user: {student}".format(student=student),str(e))
             self.log.error("Make sure you start your service with a valid 'api_token' in your Jupyterhub config")
             return []
         courses = set()

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -31,6 +31,9 @@ else:
 class JupyterhubEnvironmentError(Exception):
     pass
 
+class JupyterhubApiError(Exception):
+    pass
+
 def query_jupyterhub_api(method, api_path, post_data=None):
     """Query Jupyterhub api
 
@@ -71,6 +74,8 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         headers=auth_header,
         json = post_data,
     )
+    if not req.ok:
+        raise JupyterhubApiError("Jupyterhub returned a status code of: " + req.status_code)
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -75,7 +75,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("Jupyterhub returned a status code of: " + req.status_code)
+        raise JupyterhubApiError("Jupyterhub returned a status code of: " + str(req.status_code))
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -75,7 +75,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("Jupyterhub returned a status code of: " + str(req.status_code))
+        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code))
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -75,7 +75,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code))
+        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code) + "for api_path: " + api_path)
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -75,7 +75,7 @@ def query_jupyterhub_api(method, api_path, post_data=None):
         json = post_data,
     )
     if not req.ok:
-        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code) + "for api_path: " + api_path)
+        raise JupyterhubApiError("JupyterhubAPI returned a status code of: " + str(req.status_code) + " for api_path: " + api_path)
 
     return req.json()
 

--- a/nbgrader/utils.py
+++ b/nbgrader/utils.py
@@ -9,7 +9,6 @@ import stat
 import logging
 import traceback
 import json
-import urllib.parse
 import contextlib
 
 from setuptools.archive_util import unpack_archive


### PR DESCRIPTION
Hi Zonca, I had some time now to finally fix some of the code and make better error messages to this amazing pull request.

Tested with Jupyterhub 0.8.1 on Ubuntu 16.04

During these fixes I realised some things that must be added to the docs, some new some old:

* Only api_token for users in the admin_users list will work.

* You must generate an `'api_token'` with with the command `jupyterhub token <some admin user>`. The default api token that is created even if the user that you are using nbgrader in is in the admin_users list does not work, so generate it manually with that command wherever your jupyterhub.sqlite file cd nbis.
* For teachers/TA's have `'formgrade-<course-id>'` as the name of your group. 
* For the students have `'nbgrader-<course-id>'` as the name, you can also ommit this because it is made for you when adding a student if they are not already in Jupyterhub config when the server is started.

Here is an example how to put both the `'api_token'` and the `'formgrade-<course-id>'`group in when you create the service.

```
c.Jupyterhub.load_groups = {
     'formgrade-gagr':['sigurdurb', 'gagr'],
     'nbgrader-gagr':[],
}
c.JupyterHub.services = [{'name':'gagr20181',
                          'url':'http://127.0.0.1:9993',
                          'api_token':'4d60feb9df9f480db1eb8b77a4ef81ad',
'command':['jupyterhub-singleuser',
           '--group=formgrade-gagr',
           '--debug',
          ],
        'user':'gagr',
        'cwd':'/home/gagr',
}]
```

Note: I only tested this on Jupyterhub, still have to test this without Jupyterhub.
But I think it is fairly safe to say that for those who need they can now run this with Jupyterhub and get relevent error messages.
